### PR TITLE
MFR updates: pin invoke, install pspp

### DIFF
--- a/mfr/Dockerfile
+++ b/mfr/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update \
     # unoconv dependencies
     && apt-get install -y \
         unoconv \
+    # pspp dependencies
+    && apt-get install -y \
+        pspp \
     && apt-get clean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*

--- a/mfr/Dockerfile
+++ b/mfr/Dockerfile
@@ -49,7 +49,8 @@ ENV UPDATE_CMD 'invoke wheelhouse && invoke install'
 # ensure unoconv can locate the uno library
 ENV PYTHONPATH=/usr/lib/python3/dist-packages
 
-RUN pip install -U invoke wheel
+RUN pip install -U wheel
+RUN pip install invoke==0.11.1
 
 WORKDIR /code
 


### PR DESCRIPTION
* MFR won't work with the latest invoke. Explicitly pin it to 0.11.1.

* Install pspp, which we will be using to replace rpy2