### PR TITLE
update MFR deps for 0.24

### DIFF
--- a/mfr/Dockerfile
+++ b/mfr/Dockerfile
@@ -19,6 +19,10 @@ RUN apt-get update \
         libxml2-dev \
         libxslt1-dev \
         zlib1g-dev \
+        # extended tiff support
+        libtiff5-dev \
+        # convert .step to jsc3d-compatible format
+        freecad \
     # unoconv dependencies
     && apt-get install -y \
         unoconv \


### PR DESCRIPTION
 * freecad is needed to convert .step files into a renderable format

 * libtiff5-dev expands the varieties of tiff files we can support