### PR TITLE
Revert unoconv back to old libreoffice mirror

### DIFF
--- a/mfr/Dockerfile
+++ b/mfr/Dockerfile
@@ -46,14 +46,15 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-ENV LIBREOFFICE_VERSION 6.0.1.1
-ENV LIBREOFFICE_ARCHIVE LibreOffice_6.0.1.1_Linux_x86-64_deb.tar.gz
+ENV LIBREOFFICE_VERSION 6.0.2.1
+ENV LIBREOFFICE_ARCHIVE LibreOffice_6.0.2.1_Linux_x86-64_deb.tar.gz
+ENV LIBREOFFICE_MIRROR_URL https://downloadarchive.documentfoundation.org/libreoffice/old/
 RUN apt-get update \
     && apt-get install -y \
         curl \
     && gpg --keyserver pool.sks-keyservers.net --recv-keys AFEEAEA3 \
-    && curl -SL "https://downloadarchive.documentfoundation.org/libreoffice/old/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
-    && curl -SL "https://downloadarchive.documentfoundation.org/libreoffice/old/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
+    && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
+    && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
     && gpg --verify "$LIBREOFFICE_ARCHIVE.asc" \
     && mkdir /tmp/libreoffice \
     && tar -xvf "$LIBREOFFICE_ARCHIVE" -C /tmp/libreoffice/ --strip-components=1 \

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update \
 RUN usermod -d /home www-data \
     && chown www-data:www-data /home
 
-ENV LIBREOFFICE_VERSION 6.0.2
+ENV LIBREOFFICE_VERSION 6.0.2.1
 ENV LIBREOFFICE_ARCHIVE LibreOffice_6.0.2.1_Linux_x86-64_deb.tar.gz
-ENV LIBREOFFICE_MIRROR_URL https://ftp.osuosl.org/pub/tdf/libreoffice/testing/
+ENV LIBREOFFICE_MIRROR_URL https://downloadarchive.documentfoundation.org/libreoffice/old/
 RUN apt-get update \
     && apt-get install -y \
         curl \


### PR DESCRIPTION
 * OSU doesn't keep historical versions around, meaning the image
   build breaks after an LO patch-level release.  Switch back to
   documentfoundation.org for now.  It appears to be faster and
   completeing the download more reliably than it used to.

 * MFR didn't get updated to the OSU mirror before.  Continue to point
   it to documentfoundation.org, but break out the mirror url into an
   envvar to simplify potential future changes.  Also sneak in a bump
   to 6.0.2.1 while we're at it.