### PR TITLE
Added elasticsearch-cloud-kubernetes:6.1.3.1

### DIFF
--- a/elasticsearch/6.1/Dockerfile
+++ b/elasticsearch/6.1/Dockerfile
@@ -14,3 +14,5 @@ ADD elasticsearch.yml /usr/share/elasticsearch/config/
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
 USER elasticsearch
+
+RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:6.1.3.1


### PR DESCRIPTION
Add support elasticsearch-cloud-kubernetes:6.1.3.1 for ES 6.1 image.

Trivial PR that installs elasticsearch-cloud-kubernetes:6.1.3.1 plugin for the Elasticsearch 6.1 image