### PR TITLE
Elasticsearch 6.2.3

### DIFF
--- a/elasticsearch/6.2/6.1/Dockerfile
+++ b/elasticsearch/6.2/6.1/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.1.1
+
+USER root
+
+ENV JQ_VERSION 1.5
+ENV JQ_SHA256 c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+RUN cd /tmp \
+    && curl -o /usr/bin/jq -SL "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
+    && echo "$JQ_SHA256  /usr/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/bin/jq
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+USER elasticsearch

--- a/elasticsearch/6.2/6.1/elasticsearch.yml
+++ b/elasticsearch/6.2/6.1/elasticsearch.yml
@@ -1,0 +1,15 @@
+network.host: 0.0.0.0
+
+processors: ${PROCESSORS:}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+

--- a/elasticsearch/6.2/6.1/tls/Dockerfile
+++ b/elasticsearch/6.2/6.1/tls/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.1.1
+
+USER root
+
+ENV JQ_VERSION 1.5
+ENV JQ_SHA256 c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+RUN cd /tmp \
+    && curl -o /usr/bin/jq -SL "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
+    && echo "$JQ_SHA256  /usr/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/bin/jq
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+USER elasticsearch
+
+RUN bin/elasticsearch-plugin install -b com.floragunn:search-guard-ssl:6.1.1-25.0
+

--- a/elasticsearch/6.2/6.1/tls/elasticsearch.yml
+++ b/elasticsearch/6.2/6.1/tls/elasticsearch.yml
@@ -1,0 +1,18 @@
+network.host: 0.0.0.0
+
+processors: ${PROCESSORS:}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+
+# see https://github.com/floragunncom/search-guard-ssl/blob/master/src/main/java/com/floragunn/searchguard/ssl/util/SSLConfigConstants.java#L28
+searchguard.ssl.transport.enabled: ${SEARCHGUARD_SSL_TRANSPORT_ENABLED:false}
+searchguard.ssl.http.enabled: ${SEARCHGUARD_SSL_HTTP_ENABLED:false}

--- a/elasticsearch/6.2/Dockerfile
+++ b/elasticsearch/6.2/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+
+USER root
+
+ENV JQ_VERSION 1.5
+ENV JQ_SHA256 c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+RUN cd /tmp \
+    && curl -o /usr/bin/jq -SL "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
+    && echo "$JQ_SHA256  /usr/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/bin/jq
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image
+COPY elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+USER elasticsearch
+
+RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:6.2.3.2

--- a/elasticsearch/6.2/elasticsearch.yml
+++ b/elasticsearch/6.2/elasticsearch.yml
@@ -1,0 +1,15 @@
+network.host: 0.0.0.0
+
+processors: ${PROCESSORS:}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+

--- a/elasticsearch/6.2/tls/Dockerfile
+++ b/elasticsearch/6.2/tls/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+
+USER root
+
+ENV JQ_VERSION 1.5
+ENV JQ_SHA256 c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d
+RUN cd /tmp \
+    && curl -o /usr/bin/jq -SL "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
+    && echo "$JQ_SHA256  /usr/bin/jq" | sha256sum -c - \
+    && chmod +x /usr/bin/jq
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_c_customized_image
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+USER elasticsearch
+
+RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:6.2.3.2
+RUN bin/elasticsearch-plugin install -b com.floragunn:search-guard-ssl:6.1.1-25.0

--- a/elasticsearch/6.2/tls/elasticsearch.yml
+++ b/elasticsearch/6.2/tls/elasticsearch.yml
@@ -1,0 +1,18 @@
+network.host: 0.0.0.0
+
+processors: ${PROCESSORS:}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+# see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+
+# see https://github.com/floragunncom/search-guard-ssl/blob/master/src/main/java/com/floragunn/searchguard/ssl/util/SSLConfigConstants.java#L28
+searchguard.ssl.transport.enabled: ${SEARCHGUARD_SSL_TRANSPORT_ENABLED:false}
+searchguard.ssl.http.enabled: ${SEARCHGUARD_SSL_HTTP_ENABLED:false}


### PR DESCRIPTION
With io.fabric8:elasticsearch-cloud-kubernetes:6.2.3.2 for use in Helm incubator/elasticsearch

Maven builds on the Kubernetes plugin have resumed and as of yesterday resolved a permissions bug - https://github.com/fabric8io/elasticsearch-cloud-kubernetes/issues/126

Tested working on GKE 1.9.6 and single container