### PR TITLE
More unoconv fixes

### DIFF
--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -70,13 +70,13 @@ RUN apt-get update \
       gpg --keyserver "$server" --recv-keys AFEEAEA3 && break || echo "Trying new server..." \
     ; done \
     && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
-    && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
-    && gpg --verify "$LIBREOFFICE_ARCHIVE.asc" \
-    && mkdir /tmp/libreoffice \
-    && tar -xvf "$LIBREOFFICE_ARCHIVE" -C /tmp/libreoffice/ --strip-components=1 \
-    && dpkg -i /tmp/libreoffice/**/*.deb \
-    && rm $LIBREOFFICE_ARCHIVE* \
-    && rm -Rf /tmp/libreoffice \
+        && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
+        && gpg --verify "$LIBREOFFICE_ARCHIVE.asc" \
+        && mkdir /tmp/libreoffice \
+        && tar -xvf "$LIBREOFFICE_ARCHIVE" -C /tmp/libreoffice/ --strip-components=1 \
+        && dpkg -i /tmp/libreoffice/**/*.deb \
+        && rm $LIBREOFFICE_ARCHIVE* \
+        && rm -Rf /tmp/libreoffice \
     && apt-get clean \
     && apt-get autoremove -y \
         curl \

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update \
 
 RUN pip install unoconv==0.8.2
 
-ENV UNO_PATH=/opt/libreoffice6.0
+ENV UNO_PATH=/opt/libreoffice6.1
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -76,4 +76,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 2002
 
-CMD ["gosu", "www-data", "/opt/libreoffice6.0/program/python", "-u", "/usr/local/bin/unoconv", "--listener", "--server=0.0.0.0", "--port=2002", "-vvv"]
+CMD ["gosu", "www-data", "/opt/libreoffice6.1/program/python", "-u", "/usr/local/bin/unoconv", "--listener", "--server=0.0.0.0", "--port=2002", "-vvv"]

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-slim-stretch
 
 RUN apt-get update \
     && apt-get install -y \

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -32,6 +32,7 @@ ENV GOSU_VERSION 1.4
 RUN apt-get update \
     && apt-get install -y \
         curl \
+        gnupg2 \
     && gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
   	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
@@ -41,6 +42,7 @@ RUN apt-get update \
     && apt-get clean \
     && apt-get autoremove -y \
         curl \
+        gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN usermod -d /home www-data \
@@ -52,6 +54,7 @@ ENV LIBREOFFICE_MIRROR_URL https://download.documentfoundation.org/libreoffice/s
 RUN apt-get update \
     && apt-get install -y \
         curl \
+        gnupg2 \
     && gpg --keyserver pool.sks-keyservers.net --recv-keys AFEEAEA3 \
     && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
     && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
@@ -64,6 +67,7 @@ RUN apt-get update \
     && apt-get clean \
     && apt-get autoremove -y \
         curl \
+        gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install unoconv==0.8.2

--- a/unoconv/Dockerfile
+++ b/unoconv/Dockerfile
@@ -33,7 +33,14 @@ RUN apt-get update \
     && apt-get install -y \
         curl \
         gnupg2 \
-    && gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && mkdir ~/.gnupg && chmod 600 ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && for server in hkp://ipv4.pool.sks-keyservers.net:80 \
+                     hkp://ha.pool.sks-keyservers.net:80 \
+                     hkp://pgp.mit.edu:80 \
+                     hkp://keyserver.pgp.com:80 \
+    ; do \
+      gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || echo "Trying new server..." \
+    ; done \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
   	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
   	&& gpg --verify /usr/local/bin/gosu.asc \
@@ -55,7 +62,13 @@ RUN apt-get update \
     && apt-get install -y \
         curl \
         gnupg2 \
-    && gpg --keyserver pool.sks-keyservers.net --recv-keys AFEEAEA3 \
+    && for server in hkp://ipv4.pool.sks-keyservers.net:80 \
+                     hkp://ha.pool.sks-keyservers.net:80 \
+                     hkp://pgp.mit.edu:80 \
+                     hkp://keyserver.pgp.com:80 \
+    ; do \
+      gpg --keyserver "$server" --recv-keys AFEEAEA3 && break || echo "Trying new server..." \
+    ; done \
     && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE" -o $LIBREOFFICE_ARCHIVE \
     && curl -SL "$LIBREOFFICE_MIRROR_URL/$LIBREOFFICE_VERSION/deb/x86_64/$LIBREOFFICE_ARCHIVE.asc" -o $LIBREOFFICE_ARCHIVE.asc \
     && gpg --verify "$LIBREOFFICE_ARCHIVE.asc" \


### PR DESCRIPTION
* Bumping LO minor version requires updating path to LO's python binary.  This will also require a PR to osf.io for local MFR development to work.
* Be explicit about debian release in the base python image
* More robust GPG handling by using multiple keyservers and disabling ipv6 lookup.
* Minor style adjustments: indentation, explicitly install/uninstall gpg